### PR TITLE
Fix/support npm publish by ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,7 @@ test:
 
 deployment:
   production:
-    branch: lerna/publish
+    branch: master
     commands:
-      - yarn publish-all
+    # because yarn has troll
+      - npm run publish-all

--- a/packages/akiya-react-component-scripts/package.json
+++ b/packages/akiya-react-component-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akiya-react-component-scripts",
-  "version": "2.0.0",
+  "version": "3.1.0",
   "description": "a fork version from create-react-app/react-scripts, for react-component publishing.",
   "repository": "purepennons/akiya-react-scripts",
   "license": "MIT",

--- a/packages/akiya-react-scripts/package.json
+++ b/packages/akiya-react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akiya-react-scripts",
-  "version": "2.0.0",
+  "version": "3.1.0",
   "description": "a fork version from create-react-app/react-scripts",
   "repository": "purepennons/akiya-react-scripts",
   "license": "MIT",


### PR DESCRIPTION
- make all package versions to v3.1.0 because npm cannot publish old version packages.
- make circle ci supporting deployment.